### PR TITLE
Routing solution proposal using Coordinators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 MVVMTestProject.xcodeproj/project.xcworkspace/xcuserdata
 MVVMTestProject.xcodeproj/xcuserdata/
+MVVMTestProject.xcworkspace/xcuserdata
 Podfile.lock
 Pods

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-MVVMTestProject.xcodeproj/project.xcworkspace/xcuserdata/martinpinka.xcuserdatad/UserInterfaceState.xcuserstate
-MVVMTestProject.xcodeproj/xcuserdata/martinpinka.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+MVVMTestProject.xcodeproj/project.xcworkspace/xcuserdata/
+MVVMTestProject.xcodeproj/xcuserdata/

--- a/MVVMTestProject.xcodeproj/project.pbxproj
+++ b/MVVMTestProject.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		D0E8AA221D9832B5007EC517 /* SeasonsTableCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E8AA1F1D9832B5007EC517 /* SeasonsTableCoordinator.swift */; };
 		D0E8AA241D983395007EC517 /* BaseController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E8AA231D983395007EC517 /* BaseController.swift */; };
 		D0E8AA261D9833B8007EC517 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E8AA251D9833B8007EC517 /* AppCoordinator.swift */; };
+		D0E8AA281D984048007EC517 /* EpisodeCreateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E8AA271D984048007EC517 /* EpisodeCreateCoordinator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,7 @@
 		D0E8AA1F1D9832B5007EC517 /* SeasonsTableCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeasonsTableCoordinator.swift; sourceTree = "<group>"; };
 		D0E8AA231D983395007EC517 /* BaseController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseController.swift; sourceTree = "<group>"; };
 		D0E8AA251D9833B8007EC517 /* AppCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		D0E8AA271D984048007EC517 /* EpisodeCreateCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EpisodeCreateCoordinator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,8 +188,8 @@
 			children = (
 				D0E8AA231D983395007EC517 /* BaseController.swift */,
 				94924C101D82C79D00CA286E /* SeasonsTableViewController.swift */,
-				94924C241D82D60700CA286E /* SeasonDetailViewController.swift */,
 				9487B6C91D8AC4450016432F /* SeasonTableViewCell.swift */,
+				94924C241D82D60700CA286E /* SeasonDetailViewController.swift */,
 				949B8DED1D8EFC9C0024D38E /* EpisodeCreateViewController.swift */,
 			);
 			name = View;
@@ -214,8 +216,9 @@
 			children = (
 				D0E8AA1D1D9832B5007EC517 /* Coordinator.swift */,
 				D0E8AA251D9833B8007EC517 /* AppCoordinator.swift */,
-				D0E8AA1E1D9832B5007EC517 /* SeasonDetailCoordinator.swift */,
 				D0E8AA1F1D9832B5007EC517 /* SeasonsTableCoordinator.swift */,
+				D0E8AA1E1D9832B5007EC517 /* SeasonDetailCoordinator.swift */,
+				D0E8AA271D984048007EC517 /* EpisodeCreateCoordinator.swift */,
 			);
 			name = Coordinator;
 			sourceTree = "<group>";
@@ -425,6 +428,7 @@
 			files = (
 				949B8DF31D8FBC4D0024D38E /* EpisodeEditViewModel.swift in Sources */,
 				94924C231D82C89200CA286E /* SeasonService.swift in Sources */,
+				D0E8AA281D984048007EC517 /* EpisodeCreateCoordinator.swift in Sources */,
 				D0E8AA261D9833B8007EC517 /* AppCoordinator.swift in Sources */,
 				D0E8AA201D9832B5007EC517 /* Coordinator.swift in Sources */,
 				94AE30961D86CDF00020A99C /* SeasonDetailViewModel.swift in Sources */,

--- a/MVVMTestProject.xcodeproj/project.pbxproj
+++ b/MVVMTestProject.xcodeproj/project.pbxproj
@@ -24,6 +24,11 @@
 		94AE309E1D86CED90020A99C /* SeasonsTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94924C201D82C80400CA286E /* SeasonsTableViewModel.swift */; };
 		94AE309F1D86CED90020A99C /* SeasonDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AE30951D86CDF00020A99C /* SeasonDetailViewModel.swift */; };
 		94AE30A01D86CED90020A99C /* EpisodeDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94924C261D82D6BE00CA286E /* EpisodeDetailViewModel.swift */; };
+		D05FF4A51D8EAF620014E4DD /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05FF4A41D8EAF620014E4DD /* Coordinator.swift */; };
+		D05FF4A71D8EE7720014E4DD /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05FF4A61D8EE7720014E4DD /* AppCoordinator.swift */; };
+		D05FF4A91D8EEA3E0014E4DD /* SeasonsTableCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05FF4A81D8EEA3E0014E4DD /* SeasonsTableCoordinator.swift */; };
+		D05FF4AB1D8EFC240014E4DD /* BaseController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05FF4AA1D8EFC240014E4DD /* BaseController.swift */; };
+		D05FF4B11D8F12120014E4DD /* SeasonDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05FF4B01D8F12120014E4DD /* SeasonDetailCoordinator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +58,11 @@
 		94AE308B1D86B5DC0020A99C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		94AE30951D86CDF00020A99C /* SeasonDetailViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeasonDetailViewModel.swift; sourceTree = "<group>"; };
 		94AE309A1D86CECA0020A99C /* Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
+		D05FF4A41D8EAF620014E4DD /* Coordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		D05FF4A61D8EE7720014E4DD /* AppCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		D05FF4A81D8EEA3E0014E4DD /* SeasonsTableCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeasonsTableCoordinator.swift; sourceTree = "<group>"; };
+		D05FF4AA1D8EFC240014E4DD /* BaseController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseController.swift; sourceTree = "<group>"; };
+		D05FF4B01D8F12120014E4DD /* SeasonDetailCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeasonDetailCoordinator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +104,7 @@
 		94924C0D1D82C79D00CA286E /* testMVVM */ = {
 			isa = PBXGroup;
 			children = (
+				D05FF4A31D8EAF540014E4DD /* Coordinators */,
 				94924C0E1D82C79D00CA286E /* AppDelegate.swift */,
 				94AE30981D86CEA50020A99C /* Services */,
 				94AE30971D86CE410020A99C /* View */,
@@ -130,6 +141,7 @@
 		94AE30971D86CE410020A99C /* View */ = {
 			isa = PBXGroup;
 			children = (
+				D05FF4AA1D8EFC240014E4DD /* BaseController.swift */,
 				94924C101D82C79D00CA286E /* SeasonsTableViewController.swift */,
 				94924C241D82D60700CA286E /* SeasonDetailViewController.swift */,
 			);
@@ -150,6 +162,17 @@
 				94AE309A1D86CECA0020A99C /* Model.swift */,
 			);
 			name = Model;
+			sourceTree = "<group>";
+		};
+		D05FF4A31D8EAF540014E4DD /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				D05FF4A41D8EAF620014E4DD /* Coordinator.swift */,
+				D05FF4A61D8EE7720014E4DD /* AppCoordinator.swift */,
+				D05FF4A81D8EEA3E0014E4DD /* SeasonsTableCoordinator.swift */,
+				D05FF4B01D8F12120014E4DD /* SeasonDetailCoordinator.swift */,
+			);
+			name = Coordinators;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -256,14 +279,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D05FF4B11D8F12120014E4DD /* SeasonDetailCoordinator.swift in Sources */,
 				94924C231D82C89200CA286E /* SeasonService.swift in Sources */,
 				94AE30961D86CDF00020A99C /* SeasonDetailViewModel.swift in Sources */,
+				D05FF4A71D8EE7720014E4DD /* AppCoordinator.swift in Sources */,
 				94924C211D82C80400CA286E /* SeasonsTableViewModel.swift in Sources */,
 				94924C251D82D60700CA286E /* SeasonDetailViewController.swift in Sources */,
 				94924C111D82C79D00CA286E /* SeasonsTableViewController.swift in Sources */,
 				94924C0F1D82C79D00CA286E /* AppDelegate.swift in Sources */,
+				D05FF4A91D8EEA3E0014E4DD /* SeasonsTableCoordinator.swift in Sources */,
 				94924C271D82D6BE00CA286E /* EpisodeDetailViewModel.swift in Sources */,
 				94AE309B1D86CECA0020A99C /* Model.swift in Sources */,
+				D05FF4AB1D8EFC240014E4DD /* BaseController.swift in Sources */,
+				D05FF4A51D8EAF620014E4DD /* Coordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -349,7 +377,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -390,7 +418,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/MVVMTestProject.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MVVMTestProject.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/MVVMTestProject.xcworkspace/contents.xcworkspacedata
+++ b/MVVMTestProject.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:MVVMTestProject.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/testMVVM/AppCoordinator.swift
+++ b/testMVVM/AppCoordinator.swift
@@ -1,0 +1,38 @@
+//
+//  AppCoordinator.swift
+//  MVVMTestProject
+//
+//  Created by Petr Zvoníček on 18.09.16.
+//  Copyright © 2016 Martin Pinka. All rights reserved.
+//
+
+import UIKit
+
+class AppCoordinator: Coordinator {
+
+    var window: UIWindow
+
+    init(window: UIWindow) {
+        self.window = window
+    }
+
+    func start() {
+        // Login state detection
+        let loggedIn = true
+
+        if (loggedIn) {
+            showSeasons()
+        } else {
+            showAuth()
+        }
+    }
+
+    func showSeasons() {
+        let seasonsCoordinator = SeasonsTableCoordinator(window: window)
+        seasonsCoordinator.start()
+    }
+
+    func showAuth() {
+        // Authentication coordinator initialization
+    }
+}

--- a/testMVVM/AppCoordinator.swift
+++ b/testMVVM/AppCoordinator.swift
@@ -8,9 +8,10 @@
 
 import UIKit
 
+/// Main entry point to the app
 class AppCoordinator: Coordinator {
 
-    var window: UIWindow
+    let window: UIWindow
 
     init(window: UIWindow) {
         self.window = window

--- a/testMVVM/AppDelegate.swift
+++ b/testMVVM/AppDelegate.swift
@@ -12,10 +12,16 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-
+    var coordinator: AppCoordinator?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+
+        window = UIWindow()
+        coordinator = AppCoordinator(window: window!)
+        coordinator?.start()
+        window?.makeKeyAndVisible()
+
         return true
     }
 

--- a/testMVVM/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/testMVVM/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/testMVVM/Base.lproj/Main.storyboard
+++ b/testMVVM/Base.lproj/Main.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="da7-Y4-7Ee">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="da7-Y4-7Ee">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
@@ -20,7 +21,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bEL-1e-rQz" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-982" y="574"/>
+            <point key="canvasLocation" x="-628" y="511"/>
         </scene>
         <!--Seasons View Controller-->
         <scene sceneID="tne-QT-ifu">
@@ -31,19 +32,19 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="UMt-z8-eIb">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="UMt-z8-eIb">
+                                <frame key="frameInset" width="600" height="600"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <outlet property="dataSource" destination="BYZ-38-t0r" id="YPN-zB-gel"/>
                                     <outlet property="delegate" destination="BYZ-38-t0r" id="gJo-Yt-QtW"/>
                                 </connections>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="UMt-z8-eIb" secondAttribute="bottom" id="C6i-gV-0Pm"/>
                             <constraint firstAttribute="trailing" secondItem="UMt-z8-eIb" secondAttribute="trailing" id="OPQ-QA-CdA"/>
@@ -54,7 +55,7 @@
                     <navigationItem key="navigationItem" id="Ttf-11-1pL"/>
                     <connections>
                         <outlet property="tableView" destination="UMt-z8-eIb" id="pDI-hC-tcY"/>
-                        <segue destination="vQX-6O-Sam" kind="show" identifier="showEpisodes" id="zCj-Om-tAG"/>
+                        <segue destination="vQX-6O-Sam" kind="show" identifier="showEpisodes" customClass="CoordinatorSegue" customModule="MVVMTestProject" customModuleProvider="target" id="zCj-Om-tAG"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -64,25 +65,25 @@
         <!--Season Detail View Controller-->
         <scene sceneID="0s0-LI-jw1">
             <objects>
-                <viewController id="vQX-6O-Sam" customClass="SeasonDetailViewController" customModule="MVVMTestProject" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="detailViewController" id="vQX-6O-Sam" customClass="SeasonDetailViewController" customModule="MVVMTestProject" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="ojM-Aw-T3Y"/>
                         <viewControllerLayoutGuide type="bottom" id="iDR-Kf-1Im"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Fki-oq-4wD">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="gmg-qY-4D8">
-                                <rect key="frame" x="0.0" y="38" width="600" height="562"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <frame key="frameInset" minY="38" width="600" height="562"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <outlet property="dataSource" destination="vQX-6O-Sam" id="Cqc-Bb-30r"/>
                                     <outlet property="delegate" destination="vQX-6O-Sam" id="wh6-My-74D"/>
                                 </connections>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="gmg-qY-4D8" secondAttribute="trailing" id="1H0-Bv-HQq"/>
                             <constraint firstItem="iDR-Kf-1Im" firstAttribute="top" secondItem="gmg-qY-4D8" secondAttribute="bottom" id="96n-vh-pxh"/>
@@ -96,7 +97,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="w0q-Hj-Zgg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1173" y="575"/>
+            <point key="canvasLocation" x="1193" y="511"/>
         </scene>
     </scenes>
 </document>

--- a/testMVVM/Base.lproj/Main.storyboard
+++ b/testMVVM/Base.lproj/Main.storyboard
@@ -59,7 +59,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-9" y="511"/>
+            <point key="canvasLocation" x="316" y="573"/>
         </scene>
         <!--Title-->
         <scene sceneID="0s0-LI-jw1">
@@ -92,21 +92,23 @@
                     <navigationItem key="navigationItem" title="Title" id="m69-9d-XQf">
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="dDB-mN-45V">
                             <connections>
-                                <segue destination="XZ0-ab-Klz" kind="presentation" id="3AR-pe-mTg"/>
+                                <action selector="handleCreateEpisodeButtonTap" destination="vQX-6O-Sam" id="VAk-Zi-A97"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="tableView" destination="gmg-qY-4D8" id="jGC-8W-JJs"/>
+                        <segue destination="XZ0-ab-Klz" kind="presentation" identifier="createSegue" customClass="CoordinatorSegue" customModule="MVVMTestProject" customModuleProvider="target" id="n9u-gz-fFc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="w0q-Hj-Zgg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1173" y="575"/>
+            <point key="canvasLocation" x="1068" y="573"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="l1U-U2-upg">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="SiH-tE-SUt" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <navigationController id="XZ0-ab-Klz" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="Bxj-91-oQD">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -116,9 +118,8 @@
                         <segue destination="jn9-HH-bkO" kind="relationship" relationship="rootViewController" id="LkQ-CP-hSY"/>
                     </connections>
                 </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="SiH-tE-SUt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2269" y="418"/>
+            <point key="canvasLocation" x="2236" y="573"/>
         </scene>
         <!--Create episode-->
         <scene sceneID="7Pn-pY-Ikx">
@@ -182,7 +183,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jRv-Bc-Lea" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3261" y="417"/>
+            <point key="canvasLocation" x="2993" y="573"/>
         </scene>
     </scenes>
 </document>

--- a/testMVVM/BaseController.swift
+++ b/testMVVM/BaseController.swift
@@ -1,0 +1,13 @@
+//
+//  BaseController.swift
+//  MVVMTestProject
+//
+//  Created by Petr Zvoníček on 18.09.16.
+//  Copyright © 2016 Martin Pinka. All rights reserved.
+//
+
+import UIKit
+
+class BaseController: UIViewController {
+
+}

--- a/testMVVM/Coordinator.swift
+++ b/testMVVM/Coordinator.swift
@@ -9,15 +9,20 @@
 import UIKit
 
 protocol Coordinator {
+    /// Triggers navigation to the corresponding controller
     func start()
+
+    /// Called when segue navigation form corresponding controller to different controller is about to start and should handle this navigation
     func navigate(from source: UIViewController, to destination: UIViewController, with identifier: String?, and sender: AnyObject?)
 }
 
+/// Navigate method is optional as in some cases we needn't use segues
 extension Coordinator {
     func navigate(from source: UIViewController, to destination: UIViewController, with identifier: String?, and sender: AnyObject?) {
     }
 }
 
+/// Used typically on view controllers to refer to it's coordinator
 protocol Coordinated {
     func getCoordinator() -> Coordinator?
 }

--- a/testMVVM/Coordinator.swift
+++ b/testMVVM/Coordinator.swift
@@ -1,0 +1,36 @@
+//
+//  Coordinator.swift
+//  MVVMTestProject
+//
+//  Created by Petr Zvoníček on 18.09.16.
+//  Copyright © 2016 Martin Pinka. All rights reserved.
+//
+
+import UIKit
+
+protocol Coordinator {
+    func start()
+    func navigate(from source: UIViewController, to destination: UIViewController, with identifier: String?, and sender: AnyObject?)
+}
+
+extension Coordinator {
+    func navigate(from source: UIViewController, to destination: UIViewController, with identifier: String?, and sender: AnyObject?) {
+    }
+}
+
+protocol Coordinated {
+    func getCoordinator() -> Coordinator?
+}
+
+class CoordinatorSegue: UIStoryboardSegue {
+
+    open var sender: AnyObject!
+
+    override func perform() {
+        guard let source = self.source as? Coordinated else {
+            return
+        }
+
+        source.getCoordinator()?.navigate(from: self.source, to: destination, with: identifier, and: sender)
+    }
+}

--- a/testMVVM/EpisodeCreateCoordinator.swift
+++ b/testMVVM/EpisodeCreateCoordinator.swift
@@ -1,0 +1,38 @@
+//
+//  EpisodeCreateCoordinator.swift
+//  MVVMTestProject
+//
+//  Created by Petr Zvoníček on 25.09.16.
+//  Copyright © 2016 Martin Pinka. All rights reserved.
+//
+
+import UIKit
+
+class EpisodeCreateCoordinator: Coordinator {
+
+    let navigationController: UINavigationController
+    let viewModel: SeasonDetailViewModel
+
+    let wrapperNavigationController: UINavigationController?
+    var viewController: EpisodeCreateViewController
+
+    init(navigationController: UINavigationController, wrapperNavigationController: UINavigationController, viewController: EpisodeCreateViewController, viewModel: SeasonDetailViewModel) {
+        self.navigationController = navigationController
+        self.wrapperNavigationController = wrapperNavigationController
+        self.viewController = viewController
+        self.viewModel = viewModel
+    }
+
+    func start() {
+        viewController.viewModel = EpisodeCreateViewModel(seasonDetailViewModel: viewModel)
+
+        if let wrapperNavigationController = wrapperNavigationController {
+            // wrapper navigation controller means VC should be presented modally
+            navigationController.present(wrapperNavigationController, animated: true, completion: nil)
+        } else {
+            // present controller normally (initializer for this case not implemented, just an exploration of a possible future case)
+            navigationController.pushViewController(viewController, animated: true)
+        }
+    }
+
+}

--- a/testMVVM/EpisodeDetailViewModel.swift
+++ b/testMVVM/EpisodeDetailViewModel.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-
-
 class EpisodeDetailViewModel {
 
     
@@ -21,7 +19,6 @@ class EpisodeDetailViewModel {
     var played: Bool {
         return model.played
     }
-    
     
     init(model: Episode) {
         self.model = model
@@ -39,16 +36,8 @@ class EpisodeDetailViewModel {
     func stop() {
         isPlaying = false
     }
-    
-    
-    
+
     func configure() {
         title = model.name 
     }
-    
-    
-    
-    
-    
-    
 }

--- a/testMVVM/Info.plist
+++ b/testMVVM/Info.plist
@@ -24,8 +24,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/testMVVM/SeasonDetailCoordinator.swift
+++ b/testMVVM/SeasonDetailCoordinator.swift
@@ -37,4 +37,15 @@ class SeasonDetailCoordinator: Coordinator {
         viewController!.coordinator = self
         navigationController?.pushViewController(viewController!, animated: true)
     }
+
+    func navigate(from source: UIViewController, to destination: UIViewController, with identifier: String?, and sender: AnyObject?) {
+        if let navigation = source.navigationController, let destination = destination as? UINavigationController, let viewController = destination.topViewController as? EpisodeCreateViewController, let viewModel = sender as? SeasonDetailViewModel, identifier == "createSegue" {
+            let coordinator = EpisodeCreateCoordinator(navigationController: navigation, wrapperNavigationController: destination, viewController: viewController, viewModel: viewModel)
+            coordinator.start()
+        }        
+    }
+
+    func showCreateEpisode(from viewModel: SeasonDetailViewModel) {
+        viewController?.performSegue(withIdentifier: "createSegue", sender: viewModel)
+    }
 }

--- a/testMVVM/SeasonDetailCoordinator.swift
+++ b/testMVVM/SeasonDetailCoordinator.swift
@@ -1,0 +1,36 @@
+//
+//  SeasonDetailCoordinator.swift
+//  MVVMTestProject
+//
+//  Created by Petr Zvoníček on 18.09.16.
+//  Copyright © 2016 Martin Pinka. All rights reserved.
+//
+
+import UIKit
+
+class SeasonDetailCoordinator: Coordinator {
+
+    var navigationController: UINavigationController?
+    var viewController: SeasonDetailViewController?
+    var viewModel: SeasonDetailViewModel
+
+    init(navigationController: UINavigationController, viewModel: SeasonDetailViewModel) {
+        self.navigationController = navigationController
+        self.viewModel = viewModel
+    }
+
+    init(navigationController: UINavigationController, viewController: SeasonDetailViewController, viewModel: SeasonDetailViewModel) {
+        self.navigationController = navigationController
+        self.viewController = viewController
+        self.viewModel = viewModel
+    }
+
+    func start() {
+        if viewController == nil {
+            viewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "detailViewController") as? SeasonDetailViewController
+        }
+        viewController!.viewModel = self.viewModel
+        viewController!.coordinator = self
+        navigationController?.pushViewController(viewController!, animated: true)
+    }
+}

--- a/testMVVM/SeasonDetailCoordinator.swift
+++ b/testMVVM/SeasonDetailCoordinator.swift
@@ -10,15 +10,18 @@ import UIKit
 
 class SeasonDetailCoordinator: Coordinator {
 
-    var navigationController: UINavigationController?
+    let navigationController: UINavigationController?
+    let viewModel: SeasonDetailViewModel
+    
     var viewController: SeasonDetailViewController?
-    var viewModel: SeasonDetailViewModel
 
+    /// Used for initialization without segue
     init(navigationController: UINavigationController, viewModel: SeasonDetailViewModel) {
         self.navigationController = navigationController
         self.viewModel = viewModel
     }
 
+    /// Used for initialization with segue
     init(navigationController: UINavigationController, viewController: SeasonDetailViewController, viewModel: SeasonDetailViewModel) {
         self.navigationController = navigationController
         self.viewController = viewController
@@ -26,6 +29,7 @@ class SeasonDetailCoordinator: Coordinator {
     }
 
     func start() {
+        // In this case we support both kinds of coordination - with and without segues. When coordinated without segue, self.viewController is nil and we need to instantiate it
         if viewController == nil {
             viewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "detailViewController") as? SeasonDetailViewController
         }

--- a/testMVVM/SeasonDetailViewController.swift
+++ b/testMVVM/SeasonDetailViewController.swift
@@ -10,14 +10,15 @@
 import Foundation
 import UIKit
 
-class SeasonDetailViewController: UIViewController {
-    
+class SeasonDetailViewController: BaseController, Coordinated {
+
     @IBOutlet var tableView: UITableView!
+
     var viewModel: SeasonDetailViewModel!
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    
+    var coordinator: SeasonDetailCoordinator?
+
+    func getCoordinator() -> Coordinator? {
+        return coordinator
     }
 }
 
@@ -34,11 +35,9 @@ extension SeasonDetailViewController: UITableViewDataSource {
     }
 }
 
-
 extension SeasonDetailViewController: UITableViewDelegate {
     
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {        
         viewModel.playEpisode(indexPath)
     }
     

--- a/testMVVM/SeasonDetailViewController.swift
+++ b/testMVVM/SeasonDetailViewController.swift
@@ -21,18 +21,8 @@ class SeasonDetailViewController: BaseController, Coordinated {
         return coordinator
     }
 
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-
-        if segue.identifier == "CreateEpisode" {
-            guard let vc = (segue.destination as? UINavigationController)?.viewControllers.first as? EpisodeCreateViewController   else {
-                assertionFailure("segue \(segue.identifier) destination vc is not SeasonDetailViewController")
-                return
-            }
-
-            vc.viewModel = EpisodeCreateViewModel(seasonDetailViewModel: viewModel)
-        }
-
-        super.prepare(for: segue, sender: sender)
+    @IBAction func handleCreateEpisodeButtonTap() {
+        coordinator?.showCreateEpisode(from: viewModel)
     }
 }
 

--- a/testMVVM/SeasonsTableCoordinator.swift
+++ b/testMVVM/SeasonsTableCoordinator.swift
@@ -10,7 +10,8 @@ import UIKit
 
 class SeasonsTableCoordinator: Coordinator {
 
-    var window: UIWindow
+    let window: UIWindow
+    
     var viewController: SeasonsViewController?
 
     init(window: UIWindow) {

--- a/testMVVM/SeasonsTableCoordinator.swift
+++ b/testMVVM/SeasonsTableCoordinator.swift
@@ -33,7 +33,7 @@ class SeasonsTableCoordinator: Coordinator {
         }
     }
 
-    func showEpisodes(viewModel: SeasonDetailViewModel) {
+    func showEpisodes(from viewModel: SeasonDetailViewModel) {
         viewController?.performSegue(withIdentifier: "showEpisodes", sender: viewModel)
 
 

--- a/testMVVM/SeasonsTableCoordinator.swift
+++ b/testMVVM/SeasonsTableCoordinator.swift
@@ -1,0 +1,43 @@
+//
+//  SeaonsTableCoordinator.swift
+//  MVVMTestProject
+//
+//  Created by Petr Zvoníček on 18.09.16.
+//  Copyright © 2016 Martin Pinka. All rights reserved.
+//
+
+import UIKit
+
+class SeasonsTableCoordinator: Coordinator {
+
+    var window: UIWindow
+    var viewController: SeasonsViewController?
+
+    init(window: UIWindow) {
+        self.window = window
+    }
+
+    func start() {
+        let navigationController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as! UINavigationController
+        viewController = navigationController.topViewController as? SeasonsViewController
+        viewController?.viewModel = SeasonsTableViewModel(seasonsServices: TestSeasonsServices())
+        viewController?.coordinator = self
+        window.rootViewController = navigationController
+    }
+
+    func navigate(from source: UIViewController, to destination: UIViewController, with identifier: String?, and sender: AnyObject?) {
+        if let navigation = source.navigationController, let destination = destination as? SeasonDetailViewController, let viewModel = sender as? SeasonDetailViewModel, identifier == "showEpisodes" {
+            let coordinator = SeasonDetailCoordinator(navigationController: navigation, viewController: destination, viewModel: viewModel)
+            coordinator.start()
+        }
+    }
+
+    func showEpisodes(viewModel: SeasonDetailViewModel) {
+        viewController?.performSegue(withIdentifier: "showEpisodes", sender: viewModel)
+
+
+        // ** demonstration of a second option of VC initialization -- without use of a segue ** 
+        //let destinationCoordinator = SeasonDetailCoordinator(navigationController: viewController!.navigationController!, viewModel:viewModel)
+        //destinationCoordinator.start()
+    }
+}

--- a/testMVVM/SeasonsTableViewController.swift
+++ b/testMVVM/SeasonsTableViewController.swift
@@ -8,42 +8,27 @@
 
 import UIKit
 
-class SeasonsViewController: UIViewController {
+class SeasonsViewController: BaseController, Coordinated {
 
     @IBOutlet weak var tableView: UITableView!
+
     var viewModel: SeasonsTableViewModel!
-    
+    var coordinator: SeasonsTableCoordinator?
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        viewModel = SeasonsTableViewModel(seasonsServices: TestSeasonsServices())
         viewModel.load()
         tableView.reloadData()
-
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+    func getCoordinator() -> Coordinator? {
+        return coordinator
     }
-    
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        super.prepare(for: segue, sender: sender)
-        
-        if segue.identifier == "showEpisodes" {
-            guard let vc = segue.destination as? SeasonDetailViewController, let viewModel = sender as? SeasonDetailViewModel  else {
-                assertionFailure("segue \(segue.identifier) destination vc is not SeasonDetailViewController")
-                return
-            }
-
-            vc.viewModel = viewModel
-        }
-    }
-    
 }
 
 extension SeasonsViewController : UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        self.performSegue(withIdentifier: "showEpisodes", sender: viewModel.seasonForIndexPath(indexPath))
+        coordinator?.showEpisodes(viewModel: viewModel.seasonForIndexPath(indexPath))
     }
 }
 
@@ -59,7 +44,6 @@ extension SeasonsViewController : UITableViewDataSource {
         cell.configure(viewModel.seasonForIndexPath(indexPath))
         return cell
     }
-    
 }
 
 

--- a/testMVVM/SeasonsTableViewController.swift
+++ b/testMVVM/SeasonsTableViewController.swift
@@ -31,7 +31,7 @@ class SeasonsViewController: BaseController, Coordinated {
 
 extension SeasonsViewController : UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        coordinator?.showEpisodes(viewModel: viewModel.seasonForIndexPath(indexPath))
+        coordinator?.showEpisodes(from: viewModel.seasonForIndexPath(indexPath))
     }
 
 }


### PR DESCRIPTION
I propose the following routing solution using the Coordinator pattern. @kafejo already opened the discussion in my commit so I guess it's time to move it here. 

The routing is designed to handle both segue and non-segue presentation. The goal is to keep all the data needed to create a view controller in coordinator initializer. This should make the "contract" more visible. Also, one of the objectives of this design is to keep the structure as flexible as possible. For this reason, it looks rather "weak" for now, but I believe we'll converge to ideal coordinator form soon.
## To do

As already discussed with @thefuntasty team, my big concern is the `View Controller` conformance to `Coordinated` protocol so I'd like to get back to it. I went through several dead-end solutions so improvement proposals are warmly welcomed!

Also, a goal is to explore a possibility to generalize some common Coordinator operations into protocol extension -- so don't worry the design looks bit conservative for now. But I don't want to get overcomplicated! This should rather be a general-ish design pattern usable without a need to integrate much code.
