### PR TITLE
Add 'Stop' concept, 'Start' generalisation, memory safety improvements

### DIFF
--- a/testMVVM/AppDelegate.swift
+++ b/testMVVM/AppDelegate.swift
@@ -46,9 +46,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
-
-
-
 }
 

--- a/testMVVM/Coordinator.swift
+++ b/testMVVM/Coordinator.swift
@@ -34,18 +34,18 @@ protocol DefaultCoordinator: Coordinator {
 }
 
 protocol PushCoordinator: DefaultCoordinator {
-    var config: ((VC) -> ())? { get }
+    var configuration: ((VC) -> ())? { get }
     var navigationController: UINavigationController { get }
 }
 
 protocol ModalCoordinator: DefaultCoordinator {
-    var config: ((VC) -> ())? { get }
+    var configuration: ((VC) -> ())? { get }
     var navigationController: UINavigationController { get }
     weak var wrapperNavigationController: UINavigationController? { get }
 }
 
 protocol PushModalCoordinator: DefaultCoordinator {
-    var config: ((VC) -> ())? { get }
+    var configuration: ((VC) -> ())? { get }
     var navigationController: UINavigationController? { get }
     weak var wrapperNavigationController: UINavigationController? { get }
 }
@@ -56,7 +56,7 @@ extension PushCoordinator where VC: UIViewController, VC: Coordinated {
             return
         }
 
-        config?(viewController)
+        configuration?(viewController)
         viewController.setCoordinator(self)
         navigationController.pushViewController(viewController, animated: true)
     }
@@ -68,7 +68,7 @@ extension ModalCoordinator where VC: UIViewController, VC: Coordinated {
             return
         }
 
-        config?(viewController)
+        configuration?(viewController)
         viewController.setCoordinator(self)
 
         if let wrapperNavigationController = wrapperNavigationController {
@@ -83,7 +83,7 @@ extension PushModalCoordinator where VC: UIViewController, VC: Coordinated {
             return
         }
 
-        config?(viewController)        
+        configuration?(viewController)
         viewController.setCoordinator(self)
 
         if let wrapperNavigationController = wrapperNavigationController {

--- a/testMVVM/Coordinator.swift
+++ b/testMVVM/Coordinator.swift
@@ -43,13 +43,13 @@ protocol PushCoordinator: DefaultCoordinator {
 protocol ModalCoordinator: DefaultCoordinator {
     var configuration: ((VC) -> ())? { get }
     var navigationController: UINavigationController { get }
-    weak var wrapperNavigationController: UINavigationController? { get }
+    weak var destinationNavigationController: UINavigationController? { get }
 }
 
 protocol PushModalCoordinator: DefaultCoordinator {
     var configuration: ((VC) -> ())? { get }
     var navigationController: UINavigationController? { get }
-    weak var wrapperNavigationController: UINavigationController? { get }
+    weak var destinationNavigationController: UINavigationController? { get }
 }
 
 extension DefaultCoordinator {
@@ -81,8 +81,8 @@ extension ModalCoordinator where VC: UIViewController, VC: Coordinated {
         configuration?(viewController)
         viewController.setCoordinator(self)
 
-        if let wrapperNavigationController = wrapperNavigationController {
-            navigationController.present(wrapperNavigationController, animated: animated, completion: nil)
+        if let destinationNavigationController = destinationNavigationController {
+            navigationController.present(destinationNavigationController, animated: animated, completion: nil)
         }
     }
 }
@@ -96,9 +96,9 @@ extension PushModalCoordinator where VC: UIViewController, VC: Coordinated {
         configuration?(viewController)
         viewController.setCoordinator(self)
 
-        if let wrapperNavigationController = wrapperNavigationController {
+        if let destinationNavigationController = destinationNavigationController {
             // wrapper navigation controller means VC should be presented modally
-            navigationController?.present(wrapperNavigationController, animated: animated, completion: nil)
+            navigationController?.present(destinationNavigationController, animated: animated, completion: nil)
         } else {
             // present controller normally (initializer for this case not implemented, just an exploration of a possible future case)
             navigationController?.pushViewController(viewController, animated: animated)

--- a/testMVVM/Coordinator.swift
+++ b/testMVVM/Coordinator.swift
@@ -31,6 +31,8 @@ extension Coordinator {
 protocol DefaultCoordinator: Coordinator {
     associatedtype VC: UIViewController
     weak var viewController: VC? { get set }
+
+    var animated: Bool { get }
 }
 
 protocol PushCoordinator: DefaultCoordinator {
@@ -50,6 +52,14 @@ protocol PushModalCoordinator: DefaultCoordinator {
     weak var wrapperNavigationController: UINavigationController? { get }
 }
 
+extension DefaultCoordinator {
+    var animated: Bool {
+        get {
+            return true
+        }
+    }
+}
+
 extension PushCoordinator where VC: UIViewController, VC: Coordinated {
     func start() {
         guard let viewController = viewController else {
@@ -58,7 +68,7 @@ extension PushCoordinator where VC: UIViewController, VC: Coordinated {
 
         configuration?(viewController)
         viewController.setCoordinator(self)
-        navigationController.pushViewController(viewController, animated: true)
+        navigationController.pushViewController(viewController, animated: animated)
     }
 }
 
@@ -72,7 +82,7 @@ extension ModalCoordinator where VC: UIViewController, VC: Coordinated {
         viewController.setCoordinator(self)
 
         if let wrapperNavigationController = wrapperNavigationController {
-            navigationController.present(wrapperNavigationController, animated: true, completion: nil)
+            navigationController.present(wrapperNavigationController, animated: animated, completion: nil)
         }
     }
 }
@@ -88,10 +98,10 @@ extension PushModalCoordinator where VC: UIViewController, VC: Coordinated {
 
         if let wrapperNavigationController = wrapperNavigationController {
             // wrapper navigation controller means VC should be presented modally
-            navigationController?.present(wrapperNavigationController, animated: true, completion: nil)
+            navigationController?.present(wrapperNavigationController, animated: animated, completion: nil)
         } else {
             // present controller normally (initializer for this case not implemented, just an exploration of a possible future case)
-            navigationController?.pushViewController(viewController, animated: true)
+            navigationController?.pushViewController(viewController, animated: animated)
         }
     }
 }

--- a/testMVVM/Coordinator.swift
+++ b/testMVVM/Coordinator.swift
@@ -33,6 +33,7 @@ protocol DefaultCoordinator: Coordinator {
     weak var viewController: VC? { get set }
 
     var animated: Bool { get }
+    weak var delegate: CoordinatorDelegate? { get }
 }
 
 protocol PushCoordinator: DefaultCoordinator {
@@ -53,9 +54,17 @@ protocol PushModalCoordinator: DefaultCoordinator {
 }
 
 extension DefaultCoordinator {
+    // default implementation if not overriden
     var animated: Bool {
         get {
             return true
+        }
+    }
+
+    // default implementation of nil delegate, should be overriden when needed
+    weak var delegate: CoordinatorDelegate? {
+        get {
+            return nil
         }
     }
 }
@@ -106,6 +115,11 @@ extension PushModalCoordinator where VC: UIViewController, VC: Coordinated {
     }
 }
 
+
+protocol CoordinatorDelegate: class {
+    func willStop(in coordinator: Coordinator)
+    func didStop(in coordinator: Coordinator)
+}
 
 /// Used typically on view controllers to refer to it's coordinator
 protocol Coordinated {

--- a/testMVVM/Coordinator.swift
+++ b/testMVVM/Coordinator.swift
@@ -12,13 +12,19 @@ protocol Coordinator {
     /// Triggers navigation to the corresponding controller
     func start()
 
+    /// Stops corresponding controller and returns back to previous one
+    func stop()
+
     /// Called when segue navigation form corresponding controller to different controller is about to start and should handle this navigation
     func navigate(from source: UIViewController, to destination: UIViewController, with identifier: String?, and sender: AnyObject?)
 }
 
-/// Navigate method is optional as in some cases we needn't use segues
+/// Navigate and stop methods are optional
 extension Coordinator {
     func navigate(from source: UIViewController, to destination: UIViewController, with identifier: String?, and sender: AnyObject?) {
+    }
+
+    func stop() {
     }
 }
 

--- a/testMVVM/EpisodeCreateCoordinator.swift
+++ b/testMVVM/EpisodeCreateCoordinator.swift
@@ -8,13 +8,19 @@
 
 import UIKit
 
+protocol EpisodeCreateCoordinatorDelegate: class {
+    func didStop(in coordinator: EpisodeCreateCoordinator)
+}
+
 class EpisodeCreateCoordinator: Coordinator {
 
     let navigationController: UINavigationController
     let viewModel: SeasonDetailViewModel
 
-    let wrapperNavigationController: UINavigationController?
-    var viewController: EpisodeCreateViewController
+    weak var wrapperNavigationController: UINavigationController?
+    weak var viewController: EpisodeCreateViewController?
+
+    weak var delegate: EpisodeCreateCoordinatorDelegate?
 
     init(navigationController: UINavigationController, wrapperNavigationController: UINavigationController, viewController: EpisodeCreateViewController, viewModel: SeasonDetailViewModel) {
         self.navigationController = navigationController
@@ -24,8 +30,13 @@ class EpisodeCreateCoordinator: Coordinator {
     }
 
     func start() {
-        viewController.viewModel = EpisodeCreateViewModel(seasonDetailViewModel: viewModel)
+        guard let viewController = viewController else {
+            return
+        }
 
+        viewController.viewModel = EpisodeCreateViewModel(seasonDetailViewModel: viewModel)
+        viewController.coordinator = self
+        
         if let wrapperNavigationController = wrapperNavigationController {
             // wrapper navigation controller means VC should be presented modally
             navigationController.present(wrapperNavigationController, animated: true, completion: nil)
@@ -35,4 +46,8 @@ class EpisodeCreateCoordinator: Coordinator {
         }
     }
 
+    func stop() {
+        delegate?.didStop(in: self)
+        viewController?.dismiss(animated: true, completion: nil)
+    }
 }

--- a/testMVVM/EpisodeCreateCoordinator.swift
+++ b/testMVVM/EpisodeCreateCoordinator.swift
@@ -30,11 +30,4 @@ class EpisodeCreateCoordinator: PushModalCoordinator {
         self.viewController = viewController
         self.viewModel = viewModel
     }
-
-    func stop() {
-        delegate?.willStop(in: self)
-        viewController?.dismiss(animated: true, completion: { 
-            self.delegate?.didStop(in: self)
-        })
-    }
 }

--- a/testMVVM/EpisodeCreateCoordinator.swift
+++ b/testMVVM/EpisodeCreateCoordinator.swift
@@ -18,7 +18,7 @@ class EpisodeCreateCoordinator: PushModalCoordinator {
     let navigationController: UINavigationController?
     let viewModel: SeasonDetailViewModel
 
-    lazy internal var config: ((EpisodeCreateViewController) -> ())? = { vc in
+    lazy internal var configuration: ((EpisodeCreateViewController) -> ())? = { vc in
         vc.viewModel = EpisodeCreateViewModel(seasonDetailViewModel: self.viewModel)
     }    
 

--- a/testMVVM/EpisodeCreateCoordinator.swift
+++ b/testMVVM/EpisodeCreateCoordinator.swift
@@ -8,14 +8,19 @@
 
 import UIKit
 
+// TODO: generalize
 protocol EpisodeCreateCoordinatorDelegate: class {
+    func willStop(in coordinator: EpisodeCreateCoordinator)
     func didStop(in coordinator: EpisodeCreateCoordinator)
 }
 
-class EpisodeCreateCoordinator: Coordinator {
-
-    let navigationController: UINavigationController
+class EpisodeCreateCoordinator: PushModalCoordinator {
+    let navigationController: UINavigationController?
     let viewModel: SeasonDetailViewModel
+
+    lazy internal var config: ((EpisodeCreateViewController) -> ())? = { vc in
+        vc.viewModel = EpisodeCreateViewModel(seasonDetailViewModel: self.viewModel)
+    }    
 
     weak var wrapperNavigationController: UINavigationController?
     weak var viewController: EpisodeCreateViewController?
@@ -29,25 +34,10 @@ class EpisodeCreateCoordinator: Coordinator {
         self.viewModel = viewModel
     }
 
-    func start() {
-        guard let viewController = viewController else {
-            return
-        }
-
-        viewController.viewModel = EpisodeCreateViewModel(seasonDetailViewModel: viewModel)
-        viewController.coordinator = self
-        
-        if let wrapperNavigationController = wrapperNavigationController {
-            // wrapper navigation controller means VC should be presented modally
-            navigationController.present(wrapperNavigationController, animated: true, completion: nil)
-        } else {
-            // present controller normally (initializer for this case not implemented, just an exploration of a possible future case)
-            navigationController.pushViewController(viewController, animated: true)
-        }
-    }
-
     func stop() {
-        delegate?.didStop(in: self)
-        viewController?.dismiss(animated: true, completion: nil)
+        delegate?.willStop(in: self)
+        viewController?.dismiss(animated: true, completion: { 
+            delegate?.didStop(in: self)
+        })
     }
 }

--- a/testMVVM/EpisodeCreateCoordinator.swift
+++ b/testMVVM/EpisodeCreateCoordinator.swift
@@ -8,12 +8,6 @@
 
 import UIKit
 
-// TODO: generalize
-protocol EpisodeCreateCoordinatorDelegate: class {
-    func willStop(in coordinator: EpisodeCreateCoordinator)
-    func didStop(in coordinator: EpisodeCreateCoordinator)
-}
-
 class EpisodeCreateCoordinator: PushModalCoordinator {
     let navigationController: UINavigationController?
     let viewModel: SeasonDetailViewModel
@@ -28,7 +22,7 @@ class EpisodeCreateCoordinator: PushModalCoordinator {
     weak var destinationNavigationController: UINavigationController?
     weak var viewController: EpisodeCreateViewController?
 
-    weak var delegate: EpisodeCreateCoordinatorDelegate?
+    weak var delegate: CoordinatorDelegate?
 
     init(navigationController: UINavigationController, destinationNavigationController: UINavigationController, viewController: EpisodeCreateViewController, viewModel: SeasonDetailViewModel) {
         self.navigationController = navigationController

--- a/testMVVM/EpisodeCreateCoordinator.swift
+++ b/testMVVM/EpisodeCreateCoordinator.swift
@@ -37,7 +37,7 @@ class EpisodeCreateCoordinator: PushModalCoordinator {
     func stop() {
         delegate?.willStop(in: self)
         viewController?.dismiss(animated: true, completion: { 
-            delegate?.didStop(in: self)
+            self.delegate?.didStop(in: self)
         })
     }
 }

--- a/testMVVM/EpisodeCreateCoordinator.swift
+++ b/testMVVM/EpisodeCreateCoordinator.swift
@@ -20,7 +20,10 @@ class EpisodeCreateCoordinator: PushModalCoordinator {
 
     lazy internal var configuration: ((EpisodeCreateViewController) -> ())? = { vc in
         vc.viewModel = EpisodeCreateViewModel(seasonDetailViewModel: self.viewModel)
-    }    
+    }
+
+    // uncomment to present controller without animation
+    // var animated: Bool = false
 
     weak var wrapperNavigationController: UINavigationController?
     weak var viewController: EpisodeCreateViewController?

--- a/testMVVM/EpisodeCreateCoordinator.swift
+++ b/testMVVM/EpisodeCreateCoordinator.swift
@@ -25,14 +25,14 @@ class EpisodeCreateCoordinator: PushModalCoordinator {
     // uncomment to present controller without animation
     // var animated: Bool = false
 
-    weak var wrapperNavigationController: UINavigationController?
+    weak var destinationNavigationController: UINavigationController?
     weak var viewController: EpisodeCreateViewController?
 
     weak var delegate: EpisodeCreateCoordinatorDelegate?
 
-    init(navigationController: UINavigationController, wrapperNavigationController: UINavigationController, viewController: EpisodeCreateViewController, viewModel: SeasonDetailViewModel) {
+    init(navigationController: UINavigationController, destinationNavigationController: UINavigationController, viewController: EpisodeCreateViewController, viewModel: SeasonDetailViewModel) {
         self.navigationController = navigationController
-        self.wrapperNavigationController = wrapperNavigationController
+        self.destinationNavigationController = destinationNavigationController
         self.viewController = viewController
         self.viewModel = viewModel
     }

--- a/testMVVM/EpisodeCreateViewController.swift
+++ b/testMVVM/EpisodeCreateViewController.swift
@@ -9,10 +9,18 @@
 import Foundation
 import UIKit
 
-class EpisodeCreateViewController: UIViewController {
+class EpisodeCreateViewController: UIViewController, Coordinated {
 
     var viewModel: EpisodeCreateViewModel!
     var coordinator: EpisodeCreateCoordinator?
+
+    func getCoordinator() -> Coordinator? {
+        return coordinator
+    }
+
+    func setCoordinator(_ coordinator: Coordinator) {
+        self.coordinator = coordinator as? EpisodeCreateCoordinator
+    }
 
     @IBOutlet weak var nameTextField:  UITextField!
 

--- a/testMVVM/EpisodeCreateViewController.swift
+++ b/testMVVM/EpisodeCreateViewController.swift
@@ -20,7 +20,6 @@ class EpisodeCreateViewController: UIViewController {
     }
 
     @IBAction func save() {
-
         _ = viewModel.save().then { _ -> Void in
             self.dismiss(animated: true, completion: nil)
             }.catch { err in

--- a/testMVVM/EpisodeCreateViewController.swift
+++ b/testMVVM/EpisodeCreateViewController.swift
@@ -12,6 +12,7 @@ import UIKit
 class EpisodeCreateViewController: UIViewController {
 
     var viewModel: EpisodeCreateViewModel!
+    var coordinator: EpisodeCreateCoordinator?
 
     @IBOutlet weak var nameTextField:  UITextField!
 
@@ -21,13 +22,13 @@ class EpisodeCreateViewController: UIViewController {
 
     @IBAction func save() {
         _ = viewModel.save().then { _ -> Void in
-            self.dismiss(animated: true, completion: nil)
+            self.coordinator?.stop()
             }.catch { err in
             print(err)
         }
     }
 
     @IBAction func cancel() {
-        self.dismiss(animated: true, completion: nil)
+        coordinator?.stop()
     }
 }

--- a/testMVVM/EpisodeCreateViewController.swift
+++ b/testMVVM/EpisodeCreateViewController.swift
@@ -31,7 +31,7 @@ class EpisodeCreateViewController: UIViewController, Coordinated {
     @IBAction func save() {
         _ = viewModel.save().then { _ -> Void in
             self.coordinator?.stop()
-            }.catch { err in
+        }.catch { err in
             print(err)
         }
     }

--- a/testMVVM/EpisodeCreateViewModel.swift
+++ b/testMVVM/EpisodeCreateViewModel.swift
@@ -26,7 +26,6 @@ class EpisodeCreateViewModel {
     }
 
     func save() -> Promise<Void> {
-
         return firstly { _ -> Promise<Episode> in
             guard let name = name, name != "" else {
                 throw EpisodeCreate.WrongName
@@ -34,9 +33,6 @@ class EpisodeCreateViewModel {
 
             return seasonService.create(episode: Episode(name: name), inSeason: season)
             }.then { episode -> Void in
-         
         }
-
     }
-
 }

--- a/testMVVM/EpisodeDetailViewModel.swift
+++ b/testMVVM/EpisodeDetailViewModel.swift
@@ -10,7 +10,6 @@ import Foundation
 import Bond
 
 class EpisodeDetailViewModel {
-
     
     fileprivate var model: Episode
 
@@ -20,7 +19,6 @@ class EpisodeDetailViewModel {
     var played: Bool {
         return model.played
     }
-
 
     init(model: Episode) {
         self.model = model
@@ -37,14 +35,8 @@ class EpisodeDetailViewModel {
     func stop() {
         isPlaying.value = false
     }
-    
-    
-    
+
     func configure() {
         title.value = model.name ?? ""
-
     }
-
 }
-
-

--- a/testMVVM/EpisodeEditViewModel.swift
+++ b/testMVVM/EpisodeEditViewModel.swift
@@ -38,7 +38,6 @@ class EpisodeEditViewModel {
     }
 
     func save() -> Promise<Void> {
-
         return firstly { _ -> Promise<Episode> in
             if !isSomethingToUpdate.value {
                 throw EpisodeEditViewModelError.NothingToUpdate
@@ -49,8 +48,5 @@ class EpisodeEditViewModel {
             }.then { episode -> Void in
 
         }
-
     }
-
-
 }

--- a/testMVVM/Model.swift
+++ b/testMVVM/Model.swift
@@ -31,6 +31,5 @@ class Episode {
 
     init(withId id: String) {
         self.id = id
-    }
-    
+    }    
 }

--- a/testMVVM/SeasonDetailCoordinator.swift
+++ b/testMVVM/SeasonDetailCoordinator.swift
@@ -49,3 +49,9 @@ class SeasonDetailCoordinator: Coordinator {
         viewController?.performSegue(withIdentifier: "createSegue", sender: viewModel)
     }
 }
+
+extension SeasonDetailCoordinator: EpisodeCreateCoordinatorDelegate {
+    func didStop(in coordinator: EpisodeCreateCoordinator) {
+        print("create coordinator finished")
+    }
+}

--- a/testMVVM/SeasonDetailCoordinator.swift
+++ b/testMVVM/SeasonDetailCoordinator.swift
@@ -13,7 +13,7 @@ class SeasonDetailCoordinator: Coordinator {
     let navigationController: UINavigationController?
     let viewModel: SeasonDetailViewModel
     
-    var viewController: SeasonDetailViewController?
+    weak var viewController: SeasonDetailViewController?
 
     /// Used for initialization without segue
     init(navigationController: UINavigationController, viewModel: SeasonDetailViewModel) {

--- a/testMVVM/SeasonDetailCoordinator.swift
+++ b/testMVVM/SeasonDetailCoordinator.swift
@@ -8,17 +8,20 @@
 
 import UIKit
 
-class SeasonDetailCoordinator: Coordinator {
+class SeasonDetailCoordinator: PushCoordinator {
+    lazy internal var config: ((SeasonDetailViewController) -> ())? = { vc in
+        vc.viewModel = self.viewModel
+    }
 
-    let navigationController: UINavigationController?
+    internal var navigationController: UINavigationController
     let viewModel: SeasonDetailViewModel
-    
-    weak var viewController: SeasonDetailViewController?
+    internal weak var viewController: SeasonDetailViewController?
 
     /// Used for initialization without segue
     init(navigationController: UINavigationController, viewModel: SeasonDetailViewModel) {
         self.navigationController = navigationController
         self.viewModel = viewModel
+        self.viewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "detailViewController") as? SeasonDetailViewController
     }
 
     /// Used for initialization with segue
@@ -28,19 +31,10 @@ class SeasonDetailCoordinator: Coordinator {
         self.viewModel = viewModel
     }
 
-    func start() {
-        // In this case we support both kinds of coordination - with and without segues. When coordinated without segue, self.viewController is nil and we need to instantiate it
-        if viewController == nil {
-            viewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "detailViewController") as? SeasonDetailViewController
-        }
-        viewController!.viewModel = self.viewModel
-        viewController!.coordinator = self
-        navigationController?.pushViewController(viewController!, animated: true)
-    }
-
     func navigate(from source: UIViewController, to destination: UIViewController, with identifier: String?, and sender: AnyObject?) {
         if let navigation = source.navigationController, let destination = destination as? UINavigationController, let viewController = destination.topViewController as? EpisodeCreateViewController, let viewModel = sender as? SeasonDetailViewModel, identifier == "createSegue" {
             let coordinator = EpisodeCreateCoordinator(navigationController: navigation, wrapperNavigationController: destination, viewController: viewController, viewModel: viewModel)
+            coordinator.delegate = self
             coordinator.start()
         }        
     }
@@ -51,6 +45,10 @@ class SeasonDetailCoordinator: Coordinator {
 }
 
 extension SeasonDetailCoordinator: EpisodeCreateCoordinatorDelegate {
+    internal func willStop(in coordinator: EpisodeCreateCoordinator) {
+        
+    }
+
     func didStop(in coordinator: EpisodeCreateCoordinator) {
         print("create coordinator finished")
     }

--- a/testMVVM/SeasonDetailCoordinator.swift
+++ b/testMVVM/SeasonDetailCoordinator.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class SeasonDetailCoordinator: PushCoordinator {
-    lazy internal var config: ((SeasonDetailViewController) -> ())? = { vc in
+    lazy internal var configuration: ((SeasonDetailViewController) -> ())? = { vc in
         vc.viewModel = self.viewModel
     }
 

--- a/testMVVM/SeasonDetailCoordinator.swift
+++ b/testMVVM/SeasonDetailCoordinator.swift
@@ -33,7 +33,7 @@ class SeasonDetailCoordinator: PushCoordinator {
 
     func navigate(from source: UIViewController, to destination: UIViewController, with identifier: String?, and sender: AnyObject?) {
         if let navigation = source.navigationController, let destination = destination as? UINavigationController, let viewController = destination.topViewController as? EpisodeCreateViewController, let viewModel = sender as? SeasonDetailViewModel, identifier == "createSegue" {
-            let coordinator = EpisodeCreateCoordinator(navigationController: navigation, wrapperNavigationController: destination, viewController: viewController, viewModel: viewModel)
+            let coordinator = EpisodeCreateCoordinator(navigationController: navigation, destinationNavigationController: destination, viewController: viewController, viewModel: viewModel)
             coordinator.delegate = self
             coordinator.start()
         }        

--- a/testMVVM/SeasonDetailCoordinator.swift
+++ b/testMVVM/SeasonDetailCoordinator.swift
@@ -44,12 +44,12 @@ class SeasonDetailCoordinator: PushCoordinator {
     }
 }
 
-extension SeasonDetailCoordinator: EpisodeCreateCoordinatorDelegate {
-    internal func willStop(in coordinator: EpisodeCreateCoordinator) {
-        
+extension SeasonDetailCoordinator: CoordinatorDelegate {
+    func willStop(in coordinator: Coordinator) {
+        print("coordinator will stop")
     }
 
-    func didStop(in coordinator: EpisodeCreateCoordinator) {
-        print("create coordinator finished")
+    func didStop(in coordinator: Coordinator) {
+        print("coordinator stopped")
     }
 }

--- a/testMVVM/SeasonDetailViewController.swift
+++ b/testMVVM/SeasonDetailViewController.swift
@@ -21,6 +21,10 @@ class SeasonDetailViewController: BaseController, Coordinated {
         return coordinator
     }
 
+    func setCoordinator(_ coordinator: Coordinator) {
+        self.coordinator = coordinator as? SeasonDetailCoordinator
+    }
+
     @IBAction func handleCreateEpisodeButtonTap() {
         coordinator?.showCreateEpisode(from: viewModel)
     }

--- a/testMVVM/SeasonService.swift
+++ b/testMVVM/SeasonService.swift
@@ -9,13 +9,11 @@
 import Foundation
 import PromiseKit
 
-
 protocol SeasonsServices {    
     func seasons() -> Promise<[Season]>
     func create(episode:Episode, inSeason season: Season) -> Promise<Episode>
     func update(episode: Episode, name: String?) -> Promise<Episode>
 }
-
 
 class TestSeasonsServices: SeasonsServices {
     
@@ -23,7 +21,6 @@ class TestSeasonsServices: SeasonsServices {
         return Promise { fulfill, reject in
             fulfill([Season(name: "season 1", episodes: [Episode(name:"aa"), Episode(name:"ab")])])
         }
-
     }
 
     func create(episode:Episode, inSeason season: Season) -> Promise<Episode> {
@@ -39,5 +36,4 @@ class TestSeasonsServices: SeasonsServices {
             fulfill(episode)
         }
     }
-
 }

--- a/testMVVM/SeasonTableViewCell.swift
+++ b/testMVVM/SeasonTableViewCell.swift
@@ -13,21 +13,16 @@ import ReactiveKit
 
 class ObservingTableViewCell: UITableViewCell {
 
-
     var onReuseBag: DisposeBag = DisposeBag()
 
     override func prepareForReuse() {
         super.prepareForReuse()
         onReuseBag.dispose()
     }
-
-
 }
 
 extension ObservingTableViewCell {
-
     func configure(_ viewModel: SeasonDetailViewModel) {
-
         if let label = textLabel {
             viewModel.title.bind(to: label.bnd_text).disposeIn(onReuseBag)
         }
@@ -35,13 +30,9 @@ extension ObservingTableViewCell {
 }
 
 extension ObservingTableViewCell {
-
     func configure(_ viewModel: EpisodeDetailViewModel) {
-
         if let label = textLabel {
             viewModel.title.bind(to: label.bnd_text).disposeIn(onReuseBag)
         }
-
-
     }
 }

--- a/testMVVM/SeasonsTableCoordinator.swift
+++ b/testMVVM/SeasonsTableCoordinator.swift
@@ -12,7 +12,7 @@ class SeasonsTableCoordinator: Coordinator {
 
     let window: UIWindow
     
-    var viewController: SeasonsViewController?
+    weak var viewController: SeasonsViewController?
 
     init(window: UIWindow) {
         self.window = window

--- a/testMVVM/SeasonsTableViewController.swift
+++ b/testMVVM/SeasonsTableViewController.swift
@@ -26,6 +26,10 @@ class SeasonsViewController: BaseController, Coordinated {
     func getCoordinator() -> Coordinator? {
         return coordinator
     }
+
+    func setCoordinator(_ coordinator: Coordinator) {
+        self.coordinator = coordinator as? SeasonsTableCoordinator
+    }
 }
 
 extension SeasonsViewController : UITableViewDelegate {

--- a/testMVVM/SeasonsTableViewController.swift
+++ b/testMVVM/SeasonsTableViewController.swift
@@ -21,7 +21,6 @@ class SeasonsViewController: BaseController, Coordinated {
         _ = viewModel.load().then { (_) -> Void in
             self.tableView.reloadData()
         }
-
     }
 
     func getCoordinator() -> Coordinator? {

--- a/testMVVM/SeasonsTableViewModel.swift
+++ b/testMVVM/SeasonsTableViewModel.swift
@@ -21,11 +21,8 @@ class SeasonsTableViewModel {
 
     @discardableResult
     func load() -> Promise<[SeasonDetailViewModel]>  {
-
         return Promise { fulfill, reject in
-
             seasonsServices.seasons().then { seasons -> Void in
-
                 self.seasons.value = seasons.map {
                     SeasonDetailViewModel(model: $0, seasonServices: self.seasonsServices)
                 }
@@ -34,14 +31,10 @@ class SeasonsTableViewModel {
             }.catch { err in
                 reject(err)
             }
-
         }
     }
 
-
-
     func seasonForIndexPath(_ indexPath: IndexPath) -> SeasonDetailViewModel {
-
         return seasons.value[indexPath.row]
     }
     


### PR DESCRIPTION
This PR further explores the Coordinator concept by adding optional "Stop" method. This can also be accompanied with StopDelegate to inform parenting coordinator about stop of it's child. Currently represented as `EpisodeCreateCoordinatorDelegate` and is meant to be generalised in the future.

Also generalises 'Start' method by adapting protocol extensions for common Coordinator behaviour such as "Push", "Modal" or "PushModal" for support of both presentation ways. The previous way to use Coordinators is still supported and suitable for more specific behaviour (as the `AppCoordinator`). 

PR also fixes serious memory issues, mainly it requires `viewController` property in Coordinator to be weak to prevent retain cycles.
